### PR TITLE
Tuning the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The plugin hooks into a custom endpoint to run the cron job. It adds a rewrite r
 
 ## Changelog
 
+### 1.0.6
+
+- Make plugin faster by using `$site->__get( 'siteurl' )` instead of `get_site_url( $site->blog_id )`. This prevents use of `switch_to_blog()` and `restore_current_blog()` functions. They are expensive and slow down the plugin.
+- For `wp_remote_get`, set `blocking` to `false`. This will allow the request to be non-blocking and not wait for the response.
+- For `wp_remote_get`, set `sslverify` to `false`. This will allow the request to be non-blocking and not wait for the response.
+
 ### 1.0.5
 
 - Update composer.json with metadata

--- a/dss-cron.php
+++ b/dss-cron.php
@@ -10,7 +10,7 @@
  * Plugin Name: DSS Cron
  * Plugin URI: https://github.com/soderlind/dss-cron
  * Description: Run wp-cron on all public sites in a multisite network.
- * Version: 1.0.5
+ * Version: 1.0.6
  * Author: Per Soderlind
  * Author URI: https://soderlind.no
  * License: GPL-2.0+
@@ -64,12 +64,16 @@ function dss_run_cron_on_all_sites(): void {
 		'spam'     => 0,
 
 	] );
-	foreach ( $sites as $site ) {
-		$url      = get_site_url( $site->blog_id );
-		$response = wp_remote_get( $url . '/wp-cron.php?doing_wp_cron' );
-		// if (is_wp_error($response)) {
-		//     ray('Failed to run wp-cron for site: ' . $url . '. Error: ' . $response->get_error_message());
+	foreach ( (array) $sites as $site ) {
+		$url      = $site->__get( 'siteurl' );
+		$response = wp_remote_get( $url . '/wp-cron.php?doing_wp_cron', [ 
+			'blocking'  => false,
+			'sslverify' => false,
+		] );
+		// if ( is_wp_error( $response ) ) {
+		// 	ray( 'Failed to run wp-cron for site: ' . $url . '. Error: ' . $response->get_error_message() );
 		// }
+		// ray( [ 'Running wp-cron for site: ' => $url, 'Response' => $response ] );
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: cron, multisite, wp-cron
 Requires at least: 5.0
 Tested up to: 6.7
-Stable tag: 1.0.5
+Stable tag: 1.0.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -20,6 +20,11 @@ DSS Cron is a WordPress plugin designed to run wp-cron on all public sites in a 
 3. The plugin will automatically add a custom rewrite rule and tag for the cron endpoint.
 
 == Changelog ==
+
+= 1.0.6 =
+* Make plugin faster by using `$site->__get( 'siteurl' )` instead of `get_site_url( $site->blog_id )`. This prevents use of `switch_to_blog()` and `restore_current_blog()` functions. They are expensive and slow down the plugin.
+* For `wp_remote_get`, set `blocking` to `false`. This will allow the request to be non-blocking and not wait for the response.
+* For `wp_remote_get, set sslverify to false. This will allow the request to be non-blocking and not wait for the response.
 
 = 1.0.5 =
 * Update composer.json with metadata


### PR DESCRIPTION
- Make plugin faster by using `$site->__get( 'siteurl' )` instead of `get_site_url( $site->blog_id )`. This prevents use of `switch_to_blog()` and `restore_current_blog()` functions. They are expensive and slow down the plugin.
- For `wp_remote_get`, set `blocking` to `false`. This will allow the request to be non-blocking and not wait for the response.
- For `wp_remote_get`, set `sslverify` to `false`. This will allow the request to be non-blocking and not wait for the response.