### PR TITLE
Bump version to 2.1.0 and add i18n POT file

### DIFF
--- a/all-sites-cron.php
+++ b/all-sites-cron.php
@@ -10,7 +10,7 @@
  * Plugin Name: All Sites Cron
  * Plugin URI: https://github.com/soderlind/all-sites-cron
  * Description: Run wp-cron on all public sites in a multisite network via REST API.
- * Version: 2.0.0
+ * Version: 2.1.0
  * Author: Per Soderlind
  * Author URI: https://soderlind.no
  * License: GPL-2.0+

--- a/languages/all-sites-cron.pot
+++ b/languages/all-sites-cron.pot
@@ -1,0 +1,106 @@
+# Copyright (C) 2026 Per Soderlind
+# This file is distributed under the GPL-2.0+.
+msgid ""
+msgstr ""
+"Project-Id-Version: All Sites Cron 2.1.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/all-sites-cron\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2026-03-06T13:35:11+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: all-sites-cron\n"
+
+#. Plugin Name of the plugin
+#: all-sites-cron.php
+msgid "All Sites Cron"
+msgstr ""
+
+#. Plugin URI of the plugin
+#: all-sites-cron.php
+msgid "https://github.com/soderlind/all-sites-cron"
+msgstr ""
+
+#. Description of the plugin
+#: all-sites-cron.php
+msgid "Run wp-cron on all public sites in a multisite network via REST API."
+msgstr ""
+
+#. Author of the plugin
+#: all-sites-cron.php
+msgid "Per Soderlind"
+msgstr ""
+
+#. Author URI of the plugin
+#: all-sites-cron.php
+msgid "https://soderlind.no"
+msgstr ""
+
+#: all-sites-cron.php:140
+#: all-sites-cron.php:271
+#: src/Cron_Runner.php:27
+msgid "This plugin requires WordPress Multisite"
+msgstr ""
+
+#: all-sites-cron.php:198
+msgid "Cron job queued to Redis for background processing"
+msgstr ""
+
+#: all-sites-cron.php:218
+msgid "Cron job queued for background processing"
+msgstr ""
+
+#. translators: %d: number of sites
+#: all-sites-cron.php:239
+#, php-format
+msgid "Running wp-cron on %d sites"
+msgstr ""
+
+#: all-sites-cron.php:280
+msgid "Redis is not available"
+msgstr ""
+
+#: all-sites-cron.php:303
+msgid "Lock held — job re-queued for later processing."
+msgstr ""
+
+#. translators: %d: seconds until retry is allowed
+#: all-sites-cron.php:352
+#, php-format
+msgid "Rate limited. Try again in %d seconds."
+msgstr ""
+
+#: src/Auth.php:52
+msgid "Authentication is enabled but no token is configured. Define ALL_SITES_CRON_AUTH_TOKEN."
+msgstr ""
+
+#: src/Auth.php:62
+msgid "Authentication required. Provide a token via Authorization header or ?token= query parameter."
+msgstr ""
+
+#: src/Auth.php:70
+msgid "Invalid authentication token."
+msgstr ""
+
+#. translators: 1: site URL 2: error message
+#: src/Cron_Runner.php:66
+#, php-format
+msgid "Error for %1$s: %2$s"
+msgstr ""
+
+#: src/Cron_Runner.php:87
+msgid "No public sites found in the network"
+msgstr ""
+
+#. translators: 1: error count 2: error details
+#: src/Cron_Runner.php:96
+#, php-format
+msgid "Completed with %1$d error(s): %2$s"
+msgstr ""
+
+#: src/Lock.php:252
+msgid "Another cron process is currently running. Please try again later."
+msgstr ""

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "all-sites-cron",
+  "version": "1.0.0",
+  "description": "Run wp-cron on all public sites in a multisite network ([REST API based](#benefits-of-rest-mode)).",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "composer test",
+    "prepare": "husky",
+    "i18n": "npm run i18n:make-pot && npm run i18n:update-po && npm run i18n:make-mo && npm run i18n:make-json && npm run i18n:make-php",
+    "i18n:make-pot": "wp i18n make-pot . languages/all-sites-cron.pot --exclude=node_modules,vendor,tests,build --domain=all-sites-cron",
+    "i18n:update-po": "wp i18n update-po languages/all-sites-cron.pot languages/",
+    "i18n:make-mo": "wp i18n make-mo languages/",
+    "i18n:make-json": "wp i18n make-json languages/ --no-purge --use-map=i18n-map.json",
+    "i18n:make-php": "wp i18n make-php languages/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/soderlind/all-sites-cron.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/soderlind/all-sites-cron/issues"
+  },
+  "homepage": "https://github.com/soderlind/all-sites-cron#readme",
+  "devDependencies": {
+    "husky": "^9.1.7"
+  }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: cron, multisite, wp-cron,redis
 Requires at least: 6.7
 Tested up to: 7.0
-Stable tag: 2.0.0
+Stable tag: 2.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
This pull request updates the All Sites Cron plugin to version 2.1.0 and introduces several improvements, including enhanced internationalization support and new project metadata. The most significant changes are the addition of a translation template file, the introduction of a `package.json` for project configuration and automation, and version updates across key files.

Version and metadata updates:

* Bumped plugin version to 2.1.0 in `all-sites-cron.php` and updated the stable tag in `readme.txt` to reflect the new release. [[1]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L13-R13) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)

Internationalization improvements:

* Added a new translation template file `languages/all-sites-cron.pot` to support localization, including all plugin strings and metadata.

Project configuration and automation:

* Introduced a `package.json` file with scripts for testing and managing internationalization tasks, as well as dev dependencies for development workflow.