### PR TITLE
Fix/logic bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## ⚙️ Changelog
 
+### 2.2.0 - 2026-07-23
+
+- Return proper HTTP status codes in sync mode (200 success, 207 partial failure, 500 failure).
+- Skip rate-limit cooldown when no sites were processed, allowing immediate retry.
+- Fix deprecated `execute_and_cleanup()` wrapper releasing unowned locks.
+- Use idiomatic `$site->siteurl` property access.
+- Add `.gitignore`, `i18n-map.json`; fix phpunit path.
+
 ### 2.0.0 - 2025-10-15
 
 **Major refactoring** — the 781-line monolith has been split into a thin orchestrator and five focused classes under `src/`.

--- a/all-sites-cron.php
+++ b/all-sites-cron.php
@@ -10,7 +10,7 @@
  * Plugin Name: All Sites Cron
  * Plugin URI: https://github.com/soderlind/all-sites-cron
  * Description: Run wp-cron on all public sites in a multisite network via REST API.
- * Version: 2.1.0
+ * Version: 2.2.0
  * Author: Per Soderlind
  * Author URI: https://soderlind.no
  * License: GPL-2.0+

--- a/all-sites-cron.php
+++ b/all-sites-cron.php
@@ -231,25 +231,29 @@ function rest_run( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
 	// Standard synchronous mode.
 	$result = $runner->execute_and_cleanup( $now_gmt, $lock );
 
+	$success    = ! empty( $result[ 'success' ] );
+	$error_code = $result[ 'error_code' ] ?? '';
+	$status     = $success ? 200 : ( 'PARTIAL_FAILURE' === $error_code ? 207 : 500 );
+
 	if ( $ga_mode ) {
-		$message = empty( $result[ 'success' ] )
-			? $result[ 'message' ]
-			: sprintf(
+		$message = $success
+			? sprintf(
 				/* translators: %d: number of sites */
-				__( 'Running wp-cron on %d sites', 'all-sites-cron' ),
+				__( 'Ran wp-cron on %d sites', 'all-sites-cron' ),
 				$result[ 'count' ]
-			);
-		return Response::create( true, $message, 200 );
+			)
+			: $result[ 'message' ];
+		return Response::create( true, $message, $status );
 	}
 
 	$payload = [
-		'success'   => (bool) ( $result[ 'success' ] ?? false ),
+		'success'   => $success,
 		'count'     => (int) ( $result[ 'count' ] ?? 0 ),
 		'message'   => (string) ( $result[ 'message' ] ?? '' ),
 		'timestamp' => gmdate( 'Y-m-d H:i:s', $now_gmt ),
 		'endpoint'  => 'rest',
 	];
-	return new \WP_REST_Response( $payload, 200 );
+	return new \WP_REST_Response( $payload, $status );
 }
 
 // ---------------------------------------------------------------------------
@@ -404,7 +408,18 @@ function run_cron_on_all_sites(): array {
  * @return array
  */
 function execute_and_cleanup( int $timestamp ): array {
-	$lock = new Lock();
+	$lock        = new Lock();
+	$lock_result = $lock->acquire();
+
+	if ( is_wp_error( $lock_result ) ) {
+		return [
+			'success'    => false,
+			'message'    => $lock_result->get_error_message(),
+			'count'      => 0,
+			'error_code' => 'LOCK_HELD',
+		];
+	}
+
 	return ( new Cron_Runner() )->execute_and_cleanup( $timestamp, $lock );
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "all-sites-cron",
-  "version": "1.0.0",
+  "version": "2.2.0",
   "description": "Run wp-cron on all public sites in a multisite network ([REST API based](#benefits-of-rest-mode)).",
   "main": "index.js",
   "directories": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: cron, multisite, wp-cron,redis
 Requires at least: 6.7
 Tested up to: 7.0
-Stable tag: 2.1.0
+Stable tag: 2.2.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -63,6 +63,13 @@ Plugin updates are handled automatically via GitHub. No need to manually downloa
 
 
 == Changelog ==
+
+= 2.2.0 =
+* Return proper HTTP status codes in sync mode (200 success, 207 partial failure, 500 failure)
+* Skip rate-limit cooldown when no sites were processed, allowing immediate retry
+* Fix deprecated execute_and_cleanup() wrapper releasing unowned locks
+* Use idiomatic $site->siteurl property access
+* Add .gitignore, i18n-map.json; fix phpunit path
 
 = 2.0.0 =
 * Major architecture refactoring: extracted Lock, Redis_Queue, Cron_Runner, Auth, and Response classes under src/

--- a/src/Cron_Runner.php
+++ b/src/Cron_Runner.php
@@ -51,7 +51,7 @@ class Cron_Runner {
 			}
 
 			foreach ( $sites as $site ) {
-				$url      = $site->__get( 'siteurl' );
+				$url      = $site->siteurl;
 				$cron_url = $url . '/wp-cron.php?doing_wp_cron=' . $doing_wp_cron;
 				$response = wp_remote_post( $cron_url, [
 					'timeout'    => $timeout,
@@ -127,11 +127,14 @@ class Cron_Runner {
 		try {
 			$result = $this->run_all_sites();
 
-			set_site_transient(
-				'all_sites_cron_last_run_ts',
-				$timestamp,
-				$cooldown > 0 ? $cooldown : ALL_SITES_CRON_DEFAULT_COOLDOWN
-			);
+			// Only set rate-limit transient when at least some sites were processed.
+			if ( ! empty( $result[ 'count' ] ) ) {
+				set_site_transient(
+					'all_sites_cron_last_run_ts',
+					$timestamp,
+					$cooldown > 0 ? $cooldown : ALL_SITES_CRON_DEFAULT_COOLDOWN
+				);
+			}
 
 			if ( empty( $result[ 'success' ] ) && ! empty( $result[ 'message' ] ) ) {
 				$error_code = $result[ 'error_code' ] ?? 'EXECUTION_FAILED';


### PR DESCRIPTION
This pull request updates the plugin to version 2.2.0 and introduces several improvements and fixes related to HTTP status codes, rate-limiting, lock handling, and code style. It also updates documentation and metadata to reflect the new version.

**HTTP Status and Error Handling:**
- The REST API now returns proper HTTP status codes in synchronous mode: 200 for success, 207 for partial failure, and 500 for failure, improving API client feedback.
- The `execute_and_cleanup()` wrapper now properly handles lock acquisition errors and returns a relevant error code and message if the lock is already held.

**Rate Limiting:**
- The rate-limit cooldown is now only set if at least some sites were processed, allowing immediate retry when no sites are processed.

**Code Quality and Maintenance:**
- Updated property access for `$site->siteurl` to use idiomatic syntax instead of the deprecated `__get()` method.
- Added `.gitignore` and `i18n-map.json` files, and fixed the PHPUnit path for better project maintenance.

**Documentation and Versioning:**
- Bumped the version to 2.2.0 in `all-sites-cron.php`, `readme.txt`, and `package.json`. Updated changelogs and stable tags to reflect the new release and its changes. [[1]](diffhunk://#diff-ec1073069c388802330515b24ffc16e0d2ee0c7250191410cb969d74824f6ba6L13-R13) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R67-R73) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R10)